### PR TITLE
fix(deny): 0.16.0 breaking changes

### DIFF
--- a/.github/workflows/flake.yml
+++ b/.github/workflows/flake.yml
@@ -7,7 +7,7 @@
 on:
   workflow_dispatch:
   pull_request:
-    branches: [ main ]
+    branches: [main]
     paths:
       - '.github/workflows/flake.yml'
       - 'src/**'
@@ -26,11 +26,9 @@ on:
       - "flake.*"
       - "*.nix"
       - "*.rs"
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
-
 jobs:
   flake-checker:
     name: Flake Checker
@@ -39,7 +37,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Check Nix flake inputs
         uses: DeterminateSystems/flake-checker-action@v8
-
   check:
     name: Check Nix Flake
     runs-on: ubuntu-22.04
@@ -51,10 +48,8 @@ jobs:
         uses: DeterminateSystems/magic-nix-cache-action@main
       - name: Nix Flake Check
         run: nix flake check --all-systems
-
   build:
     name: Build Nix package
-
     # if cross compilation is desired add 'aarch64-linux', 'x86_64-darwin' and 'aarch64-darwin' and fix the flake to support cross compilation.
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,11 +4,10 @@
 # SPDX-License-Identifier: EUPL-1.2
 
 name: test
-
 on:
   pull_request:
   push:
-    branches: [ main ]
+    branches: [main]
     paths:
       - '.github/workflows/test.yml'
       - 'src/**'
@@ -17,15 +16,12 @@ on:
       - "flake.*"
       - "*.nix"
       - "*.rs"
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
-
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -Dwarnings
-
 jobs:
   tests:
     runs-on: ${{ matrix.os }}
@@ -35,10 +31,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
       - run: rustup toolchain install stable --profile minimal
       - uses: Swatinem/rust-cache@v2
-
       - run: cargo fmt --check
       - run: cargo clippy --workspace
       - run: cargo build --workspace

--- a/deny.toml
+++ b/deny.toml
@@ -98,7 +98,14 @@ ignore = [
 # - "BSD-4-Clause": GPL incompatible
 # - "OpenSSL": GPL incompatible
 # - "GPL-2.0": GPL3 incompatible
-allow = ["MIT", "Apache-2.0", "ISC", "Unicode-DFS-2016", "BSD-3-Clause"]
+allow = [
+  "MIT",
+  "Apache-2.0",
+  "ISC",
+  "Unicode-DFS-2016",
+  "BSD-3-Clause",
+  "EUPL-1.2",
+]
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the
 # canonical license text of a valid SPDX license file.

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "advisory-db": {
       "flake": false,
       "locked": {
-        "lastModified": 1717596017,
-        "narHash": "sha256-LHjTqlOLgtv43GVkeM7Hb5HcZG5i/vNHnWgYaUzu+Jg=",
+        "lastModified": 1722017365,
+        "narHash": "sha256-9wYR5NZIgI+qzMDlJrUzevR31fvFQRgfjlYp50Xp3Ts=",
         "owner": "rustsec",
         "repo": "advisory-db",
-        "rev": "af76d4423761499f954411bb3071dcc72e6b0450",
+        "rev": "9d024c07ee8c18609b43436bc865abf46636e250",
         "type": "github"
       },
       "original": {
@@ -23,11 +23,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718078026,
-        "narHash": "sha256-LbQabH6h86ZzTvDnaZHmMwedRZNB2jYtUQzmoqWQoJ8=",
+        "lastModified": 1722809451,
+        "narHash": "sha256-2Yt/0zGpJ784h0rffj9fQTyqflJkNPmW7gsmPknluus=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "a3f0c63eed74a516298932b9b1627dd80b9c3892",
+        "rev": "c873fd2ad80e32cd2c427df5a248a3f7baafc1ae",
         "type": "github"
       },
       "original": {
@@ -44,11 +44,11 @@
         "rust-analyzer-src": []
       },
       "locked": {
-        "lastModified": 1717827974,
-        "narHash": "sha256-ixopuTeTouxqTxfMuzs6IaRttbT8JqRW5C9Q/57WxQw=",
+        "lastModified": 1722839439,
+        "narHash": "sha256-AwQv9kstzEOYjzuC9uY8jECqFJPuV/UxPLa30L3DLqo=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "ab655c627777ab5f9964652fe23bbb1dfbd687a8",
+        "rev": "1388e72dd8562c8b2908fd655dee0c797df9e930",
         "type": "github"
       },
       "original": {
@@ -115,11 +115,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1718149104,
-        "narHash": "sha256-Ds1QpobBX2yoUDx9ZruqVGJ/uQPgcXoYuobBguyKEh8=",
+        "lastModified": 1722640603,
+        "narHash": "sha256-TcXjLVNd3VeH1qKPH335Tc4RbFDbZQX+d7rqnDUoRaY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e913ae340076bbb73d9f4d3d065c2bca7caafb16",
+        "rev": "81610abc161d4021b29199aa464d6a1a521e0cc9",
         "type": "github"
       },
       "original": {
@@ -131,11 +131,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1718208800,
-        "narHash": "sha256-US1tAChvPxT52RV8GksWZS415tTS7PV42KTc2PNDBmc=",
+        "lastModified": 1722651103,
+        "narHash": "sha256-IRiJA0NVAoyaZeKZluwfb2DoTpBAj+FLI0KfybBeDU0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cc54fb41d13736e92229c21627ea4f22199fee6b",
+        "rev": "a633d89c6dc9a2a8aae11813a62d7c58b2c0cc51",
         "type": "github"
       },
       "original": {
@@ -161,11 +161,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717664902,
-        "narHash": "sha256-7XfBuLULizXjXfBYy/VV+SpYMHreNRHk9nKMsm1bgb4=",
+        "lastModified": 1721042469,
+        "narHash": "sha256-6FPUl7HVtvRHCCBQne7Ylp4p+dpP3P/OYuzjztZ4s70=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "cc4d466cb1254af050ff7bdf47f6d404a7c646d1",
+        "rev": "f451c19376071a90d8c58ab1a953c6e9840527fd",
         "type": "github"
       },
       "original": {
@@ -192,19 +192,16 @@
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": [
-          "flake-utils"
-        ],
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1718331519,
-        "narHash": "sha256-6Ru37wS8uec626nHVIh6hSpCYB7eNc3RPFa2U//bhw4=",
+        "lastModified": 1722824458,
+        "narHash": "sha256-2k3/geD5Yh8JT1nrGaRycje5kB0DkvQA/OUZoel1bIU=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "419e7fae2731f41dd9b3e34dfe8802be68558b92",
+        "rev": "a8a937c304e62a5098c6276c9cdf65c19a43b1a5",
         "type": "github"
       },
       "original": {
@@ -235,11 +232,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718271476,
-        "narHash": "sha256-35hUMmFesmchb+u7heKHLG5B6c8fBOcSYo0jj0CHLes=",
+        "lastModified": 1722330636,
+        "narHash": "sha256-uru7JzOa33YlSRwf9sfXpJG+UAV+bnBEYMjrzKrQZFw=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "e75ba0a6bb562d2ce275db28f6a36a2e4fd81391",
+        "rev": "768acdb06968e53aa1ee8de207fd955335c754b7",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -225,7 +225,7 @@
 
           # Additional dev-shell environment variables can be set directly
           # MY_CUSTOM_DEVELOPMENT_VAR = "something else";
-          packages = with pkgs; [rustup toolchain just zip reuse pkg-config openssl statix convco] ++ self.checks.${system}.pre-commit-check.enabledPackages;
+          packages = with pkgs; [rustup toolchain cargo-deny just zip reuse pkg-config openssl statix convco] ++ self.checks.${system}.pre-commit-check.enabledPackages;
           inherit (self.checks.${system}.pre-commit-check) shellHook;
         };
 

--- a/flake.nix
+++ b/flake.nix
@@ -70,72 +70,74 @@
     };
   };
 
-  outputs = {
-    self,
-    flake-utils,
-    nixpkgs,
-    treefmt-nix,
-    rust-overlay,
-    pre-commit-hooks,
-    crane,
-    fenix,
-    advisory-db,
-    ...
-  }:
-    flake-utils.lib.eachDefaultSystem (
-      system: let
-        overlays = [(import rust-overlay)];
+  outputs =
+    { self
+    , flake-utils
+    , nixpkgs
+    , treefmt-nix
+    , rust-overlay
+    , pre-commit-hooks
+    , crane
+    , fenix
+    , advisory-db
+    , ...
+    }:
+    flake-utils.lib.eachDefaultSystem
+      (
+        system:
+        let
+          overlays = [ (import rust-overlay) ];
 
-        pkgs = (import nixpkgs) {
-          inherit system overlays;
-        };
+          pkgs = (import nixpkgs) {
+            inherit system overlays;
+          };
 
-        inherit (pkgs) lib;
+          inherit (pkgs) lib;
 
-        toolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+          toolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
 
-        craneLib = (crane.mkLib pkgs).overrideToolchain toolchain;
-        src = craneLib.cleanCargoSource (craneLib.path ./.);
+          craneLib = (crane.mkLib pkgs).overrideToolchain toolchain;
+          src = craneLib.cleanCargoSource (craneLib.path ./.);
 
-        darwinBuildInputs = with pkgs; with darwin.apple_sdk.frameworks; [libiconv Security SystemConfiguration];
+          darwinBuildInputs = with pkgs; with darwin.apple_sdk.frameworks; [ libiconv Security SystemConfiguration ];
 
-        # Common arguments can be set here to avoid repeating them later
-        commonArgs = {
-          inherit src;
-          strictDeps = true;
+          # Common arguments can be set here to avoid repeating them later
+          commonArgs = {
+            inherit src;
+            strictDeps = true;
 
-          buildInputs = with pkgs;
-            [
-              # Add additional build inputs here
-              openssl
-            ]
-            ++ lib.optionals pkgs.stdenv.isDarwin darwinBuildInputs;
+            buildInputs = with pkgs;
+              [
+                # Add additional build inputs here
+                openssl
+              ]
+              ++ lib.optionals pkgs.stdenv.isDarwin darwinBuildInputs;
 
-          # Additional environment variables can be set directly
-          # MY_CUSTOM_VAR = "some value";
+            # Additional environment variables can be set directly
+            # MY_CUSTOM_VAR = "some value";
 
-          nativeBuildInputs = with pkgs; [
-            makeWrapper
-            installShellFiles
-            pkg-config
-          ];
-        };
+            nativeBuildInputs = with pkgs; [
+              makeWrapper
+              installShellFiles
+              pkg-config
+            ];
+          };
 
-        craneLibLLvmTools =
-          craneLib.overrideToolchain
-          (fenix.packages.${system}.complete.withComponents [
-            "cargo"
-            "llvm-tools"
-            "rustc"
-          ]);
+          craneLibLLvmTools =
+            craneLib.overrideToolchain
+              (fenix.packages.${system}.complete.withComponents [
+                "cargo"
+                "llvm-tools"
+                "rustc"
+              ]);
 
-        # Build *just* the cargo dependencies, so we can reuse
-        # all of that work (e.g. via cachix) when running in CI
-        cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+          # Build *just* the cargo dependencies, so we can reuse
+          # all of that work (e.g. via cachix) when running in CI
+          cargoArtifacts = craneLib.buildDepsOnly commonArgs;
 
-        # Build the actual crate itself, reusing the dependency
-        # artifacts from above.
-        ha-registry = craneLib.buildPackage (commonArgs
+          # Build the actual crate itself, reusing the dependency
+          # artifacts from above.
+          ha-registry = craneLib.buildPackage (commonArgs
           // {
             inherit cargoArtifacts;
 
@@ -157,154 +159,156 @@
             meta.mainProgram = "ha-registry";
           });
 
-        treefmtEval = treefmt-nix.lib.evalModule pkgs ./treefmt.nix;
-      in rec {
-        # For `nix fmt`
-        formatter = treefmtEval.config.build.wrapper;
+          treefmtEval = treefmt-nix.lib.evalModule pkgs ./treefmt.nix;
+        in
+        rec {
+          # For `nix fmt`
+          formatter = treefmtEval.config.build.wrapper;
 
-        packages =
-          {
-            default = ha-registry;
+          packages =
+            {
+              default = ha-registry;
 
-            container = pkgs.dockerTools.buildLayeredImage {
-              name = "ha-tregistry";
-              tag = "latest";
-              contents = [packages.default pkgs.cacert];
-              config = {
-                Labels = {
-                  "org.opencontainers.image.source" = "https://github.com/cafkafk/ha-registry";
-                  "org.opencontainers.image.description" = "ha-registry: High Availability Container Registry";
-                  "org.opencontainers.image.license" = "EUPL-1.2";
+              container = pkgs.dockerTools.buildLayeredImage {
+                name = "ha-tregistry";
+                tag = "latest";
+                contents = [ packages.default pkgs.cacert ];
+                config = {
+                  Labels = {
+                    "org.opencontainers.image.source" = "https://github.com/cafkafk/ha-registry";
+                    "org.opencontainers.image.description" = "ha-registry: High Availability Container Registry";
+                    "org.opencontainers.image.license" = "EUPL-1.2";
+                  };
+                  Env = [
+                    "RUST_LOG=trace"
+                  ];
+                  Cmd = [ "/bin/ha-registry" ];
                 };
-                Env = [
-                  "RUST_LOG=trace"
-                ];
-                Cmd = ["/bin/ha-registry"];
-              };
-            };
-
-            distribution-spec = pkgs.buildGoModule rec {
-              name = "distribution-spec";
-              version = "1.1.0";
-
-              src = pkgs.fetchFromGitHub {
-                owner = "opencontainers";
-                repo = "distribution-spec";
-                rev = "v${version}";
-                hash = "sha256-GL28YUwDRicxS65E7SDR/Q3tJOWN4iwgq4AGBjwVPzA=";
               };
 
-              buildPhase = ''
-                go test -c -o conformance.test
-              '';
+              distribution-spec = pkgs.buildGoModule rec {
+                name = "distribution-spec";
+                version = "1.1.0";
 
-              installPhase = ''
-                mkdir -p $out/bin
-                cp conformance.test $out/bin
-              '';
+                src = pkgs.fetchFromGitHub {
+                  owner = "opencontainers";
+                  repo = "distribution-spec";
+                  rev = "v${version}";
+                  hash = "sha256-GL28YUwDRicxS65E7SDR/Q3tJOWN4iwgq4AGBjwVPzA=";
+                };
 
-              vendorHash = "sha256-5gn9RpjCALZB/GFjlJHDqPs2fIHl7NJr5QjPmsLnnO4=";
-              modRoot = "conformance";
-            };
-          }
-          // lib.optionalAttrs (!pkgs.stdenv.isDarwin) {
-            serde-yaml-llvm-coverage = craneLibLLvmTools.cargoLlvmCov (commonArgs
+                buildPhase = ''
+                  go test -c -o conformance.test
+                '';
+
+                installPhase = ''
+                  mkdir -p $out/bin
+                  cp conformance.test $out/bin
+                '';
+
+                vendorHash = "sha256-5gn9RpjCALZB/GFjlJHDqPs2fIHl7NJr5QjPmsLnnO4=";
+                modRoot = "conformance";
+              };
+            }
+            // lib.optionalAttrs (!pkgs.stdenv.isDarwin) {
+              serde-yaml-llvm-coverage = craneLibLLvmTools.cargoLlvmCov (commonArgs
               // {
                 inherit cargoArtifacts;
               });
+            };
+
+          apps.default = flake-utils.lib.mkApp {
+            drv = ha-registry;
           };
 
-        apps.default = flake-utils.lib.mkApp {
-          drv = ha-registry;
-        };
+          # For `nix develop`:
+          devShells.default = craneLib.devShell {
+            # Inherit inputs from checks.
+            checks = self.checks.${system};
 
-        # For `nix develop`:
-        devShells.default = craneLib.devShell {
-          # Inherit inputs from checks.
-          checks = self.checks.${system};
+            # Additional dev-shell environment variables can be set directly
+            # MY_CUSTOM_DEVELOPMENT_VAR = "something else";
+            packages = with pkgs; [ rustup toolchain cargo-deny just zip reuse pkg-config openssl statix convco ] ++ self.checks.${system}.pre-commit-check.enabledPackages;
+            inherit (self.checks.${system}.pre-commit-check) shellHook;
+          };
 
-          # Additional dev-shell environment variables can be set directly
-          # MY_CUSTOM_DEVELOPMENT_VAR = "something else";
-          packages = with pkgs; [rustup toolchain cargo-deny just zip reuse pkg-config openssl statix convco] ++ self.checks.${system}.pre-commit-check.enabledPackages;
-          inherit (self.checks.${system}.pre-commit-check) shellHook;
-        };
+          # For `nix flake check`
+          checks = {
+            # Build the crate as part of `nix flake check` for convenience
+            inherit ha-registry;
 
-        # For `nix flake check`
-        checks = {
-          # Build the crate as part of `nix flake check` for convenience
-          inherit ha-registry;
-
-          # Run clippy (and deny all warnings) on the crate source,
-          # again, reusing the dependency artifacts from above.
-          #
-          # Note that this is done as a separate derivation so that
-          # we can block the CI if there are issues here, but not
-          # prevent downstream consumers from building our crate by itself.
-          ha-registry-clippy = craneLib.cargoClippy (commonArgs
+            # Run clippy (and deny all warnings) on the crate source,
+            # again, reusing the dependency artifacts from above.
+            #
+            # Note that this is done as a separate derivation so that
+            # we can block the CI if there are issues here, but not
+            # prevent downstream consumers from building our crate by itself.
+            ha-registry-clippy = craneLib.cargoClippy (commonArgs
             // {
               inherit cargoArtifacts;
               cargoClippyExtraArgs = "--all-targets -- --deny warnings";
             });
 
-          ha-registry-doc = craneLib.cargoDoc (commonArgs
+            ha-registry-doc = craneLib.cargoDoc (commonArgs
             // {
               inherit cargoArtifacts;
             });
 
-          # Check formatting
-          ha-registry-fmt = craneLib.cargoFmt {
-            inherit src;
-          };
+            # Check formatting
+            ha-registry-fmt = craneLib.cargoFmt {
+              inherit src;
+            };
 
-          # Audit dependencies
-          ha-registry-audit = craneLib.cargoAudit {
-            inherit src advisory-db;
-          };
+            # Audit dependencies
+            ha-registry-audit = craneLib.cargoAudit {
+              inherit src advisory-db;
+            };
 
-          # Audit licenses
-          ha-registry-deny = craneLib.cargoDeny {
-            inherit src;
-          };
+            # Audit licenses
+            ha-registry-deny = craneLib.cargoDeny {
+              inherit src;
+            };
 
-          # Run tests with cargo-nextest
-          # Consider setting `doCheck = false` on `ha-registry` if you do not want
-          # the tests to run twice
-          ha-registry-nextest = craneLib.cargoNextest (commonArgs
+            # Run tests with cargo-nextest
+            # Consider setting `doCheck = false` on `ha-registry` if you do not want
+            # the tests to run twice
+            ha-registry-nextest = craneLib.cargoNextest (commonArgs
             // {
               inherit cargoArtifacts;
               partitions = 1;
               partitionType = "count";
             });
 
-          status = pkgs.callPackage ./nixos/tests/status.nix {inherit packages;};
+            status = pkgs.callPackage ./nixos/tests/status.nix { inherit packages; };
 
-          pre-commit-check = let
-            # some treefmt formatters are not supported in pre-commit-hooks we filter them out for now.
-            toFilter = ["yamlfmt"];
-            filterFn = n: _v: (!builtins.elem n toFilter);
-            treefmtFormatters = pkgs.lib.mapAttrs (_n: v: {inherit (v) enable;}) (pkgs.lib.filterAttrs filterFn (import ./treefmt.nix).programs);
-          in
-            pre-commit-hooks.lib.${system}.run {
-              src = ./.;
-              hooks =
-                treefmtFormatters
-                // {
-                  convco.enable = true; # not in treefmt
-                  reuse = {
-                    enable = true;
-                    name = "reuse";
-                    entry = with pkgs; "${pkgs.reuse}/bin/reuse lint";
-                    pass_filenames = false;
+            pre-commit-check =
+              let
+                # some treefmt formatters are not supported in pre-commit-hooks we filter them out for now.
+                toFilter = [ "yamlfmt" ];
+                filterFn = n: _v: (!builtins.elem n toFilter);
+                treefmtFormatters = pkgs.lib.mapAttrs (_n: v: { inherit (v) enable; }) (pkgs.lib.filterAttrs filterFn (import ./treefmt.nix).programs);
+              in
+              pre-commit-hooks.lib.${system}.run {
+                src = ./.;
+                hooks =
+                  treefmtFormatters
+                  // {
+                    convco.enable = true; # not in treefmt
+                    reuse = {
+                      enable = true;
+                      name = "reuse";
+                      entry = with pkgs; "${pkgs.reuse}/bin/reuse lint";
+                      pass_filenames = false;
+                    };
                   };
-                };
-            };
-          formatting = treefmtEval.config.build.check self;
-        };
-      }
-    )
+              };
+            formatting = treefmtEval.config.build.check self;
+          };
+        }
+      )
     // {
       nixosModules = {
-        ha-registry = {imports = [./nixos/modules/ha-registry.nix];};
+        ha-registry = { imports = [ ./nixos/modules/ha-registry.nix ]; };
       };
     };
 }

--- a/nixos/modules/default.nix
+++ b/nixos/modules/default.nix
@@ -2,7 +2,7 @@
 # SPDX-FileContributor: Christina Sørensen
 #
 # SPDX-License-Identifier: EUPL-1.2
-{...}: {
+{ ... }: {
   imports = [
     ./ha-registry.nix
   ];

--- a/nixos/modules/ha-registry.nix
+++ b/nixos/modules/ha-registry.nix
@@ -2,11 +2,10 @@
 # SPDX-FileContributor: Christina Sørensen
 #
 # SPDX-License-Identifier: EUPL-1.2
-{
-  config,
-  lib,
-  pkgs,
-  ...
+{ config
+, lib
+, pkgs
+, ...
 }:
 with lib; let
   cfg = config.services.ha-registry;
@@ -15,12 +14,13 @@ with lib; let
 
   port = 3000;
 
-  settingsFormat = pkgs.formats.yaml {};
-in {
+  settingsFormat = pkgs.formats.yaml { };
+in
+{
   options.services.ha-registry = {
     enable = mkEnableOption "ha-registry";
 
-    package = mkPackageOption pkgs "ha-registry" {};
+    package = mkPackageOption pkgs "ha-registry" { };
 
     openFirewall = mkEnableOption "opening the default ports in the firewall for ha-registry";
 
@@ -55,9 +55,9 @@ in {
     systemd.services.ha-registry = {
       enable = true;
       description = "ha-registry";
-      wants = ["network-online.target"];
-      wantedBy = ["multi-user.target"];
-      after = ["network-online.target"];
+      wants = [ "network-online.target" ];
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network-online.target" ];
 
       environment = {
         # FIXME: consider doing this directly in aws-sdk it may have
@@ -67,9 +67,11 @@ in {
 
       serviceConfig = {
         Restart = "always";
-        ExecStart = let
-          args = [];
-        in "${cfg.package}/bin/ha-registry ${concatStringsSep " " args} --config ${settingsFormat.generate "registry-config.yaml" cfg.settings}";
+        ExecStart =
+          let
+            args = [ ];
+          in
+          "${cfg.package}/bin/ha-registry ${concatStringsSep " " args} --config ${settingsFormat.generate "registry-config.yaml" cfg.settings}";
         # Ensure registry isn't considered started before listening for
         # connections
         Type = "notify";
@@ -78,9 +80,9 @@ in {
     };
 
     networking.firewall = mkIf cfg.openFirewall {
-      allowedTCPPorts = [cfg.settings.port];
+      allowedTCPPorts = [ cfg.settings.port ];
     };
 
-    meta.maintainers = [cafkafk];
+    meta.maintainers = [ cafkafk ];
   };
 }

--- a/nixos/tests/status.nix
+++ b/nixos/tests/status.nix
@@ -2,103 +2,103 @@
 # SPDX-FileContributor: Christina Sørensen
 #
 # SPDX-License-Identifier: EUPL-1.2
-{
-  lib,
-  nixosTest,
-  packages,
-  ...
+{ lib
+, nixosTest
+, packages
+, ...
 }:
 nixosTest {
   name = "ha-registry status test";
 
-  nodes = let
-    minioAccessKey = "legit";
-    minioSecretKey = "111-1111111";
-    minio = _: {
-      services.minio = {
-        enable = true;
-        rootCredentialsFile = "/etc/minio.env";
+  nodes =
+    let
+      minioAccessKey = "legit";
+      minioSecretKey = "111-1111111";
+      minio = _: {
+        services.minio = {
+          enable = true;
+          rootCredentialsFile = "/etc/minio.env";
+        };
+
+        # For testing only - Don't actually do this
+        environment.etc."minio.env".text = ''
+          MINIO_ROOT_USER=${minioAccessKey}
+          MINIO_ROOT_PASSWORD=${minioSecretKey}
+        '';
+
+        networking.firewall.allowedTCPPorts = [ 9000 ];
       };
+      postgres = _: {
+        systemd.services.postgresql.postStart = lib.mkAfter ''
+          $PSQL -tAc 'ALTER DATABASE "registry" OWNER TO "registry"'
+        '';
 
-      # For testing only - Don't actually do this
-      environment.etc."minio.env".text = ''
-        MINIO_ROOT_USER=${minioAccessKey}
-        MINIO_ROOT_PASSWORD=${minioSecretKey}
-      '';
+        services.postgresql = {
+          enable = true;
+          ensureDatabases = [ "registry" ];
+          ensureUsers = [
+            {
+              name = "registry";
+            }
 
-      networking.firewall.allowedTCPPorts = [9000];
-    };
-    postgres = _: {
-      systemd.services.postgresql.postStart = lib.mkAfter ''
-        $PSQL -tAc 'ALTER DATABASE "registry" OWNER TO "registry"'
-      '';
+            # For testing only - Don't actually do this
+            {
+              name = "root";
+              ensureClauses = {
+                superuser = true;
+              };
+            }
+          ];
+        };
+      };
+    in
+    {
+      inherit minio postgres;
 
-      services.postgresql = {
-        enable = true;
-        ensureDatabases = ["registry"];
-        ensureUsers = [
-          {
-            name = "registry";
-          }
-
-          # For testing only - Don't actually do this
-          {
-            name = "root";
-            ensureClauses = {
-              superuser = true;
-            };
-          }
+      haregistry = { ... }: {
+        imports = [
+          ../modules/ha-registry.nix
         ];
-      };
-    };
-  in {
-    inherit minio postgres;
 
-    haregistry = {...}: {
-      imports = [
-        ../modules/ha-registry.nix
-      ];
+        services.etcd = {
+          enable = true;
 
-      services.etcd = {
-        enable = true;
+          openFirewall = true;
+        };
 
-        openFirewall = true;
-      };
+        systemd.services.ha-registry.environment = {
+          RUST_BACKTRACE = "full";
+          RUST_LOG = "trace";
+        };
 
-      systemd.services.ha-registry.environment = {
-        RUST_BACKTRACE = "full";
-        RUST_LOG = "trace";
-      };
+        services.ha-registry = {
+          enable = true;
+          package = packages.default;
 
-      services.ha-registry = {
-        enable = true;
-        package = packages.default;
+          openFirewall = true;
 
-        openFirewall = true;
+          # services.atticd.settings = {
+          #   database.url = "postgresql:///registry?host=/run/postgresql";
+          # };
 
-        # services.atticd.settings = {
-        #   database.url = "postgresql:///registry?host=/run/postgresql";
-        # };
-
-        settings = {
-          addr = "0.0.0.0";
-          port = 3000;
-          s3 = {
-            region = "us-east-1";
-            bucket = "registry";
-            endpoint = "http://minio:9000";
-            credentials = {
-              access_key_id = minioAccessKey;
-              secret_access_key = minioSecretKey;
+          settings = {
+            addr = "0.0.0.0";
+            port = 3000;
+            s3 = {
+              region = "us-east-1";
+              bucket = "registry";
+              endpoint = "http://minio:9000";
+              credentials = {
+                access_key_id = minioAccessKey;
+                secret_access_key = minioSecretKey;
+              };
             };
           };
         };
       };
-    };
 
-    client1 = _: {
+      client1 = _: { };
     };
-  };
 
   testScript = ''
     start_all()

--- a/treefmt.nix
+++ b/treefmt.nix
@@ -5,7 +5,7 @@
 {
   projectRootFile = "Cargo.toml";
   programs = {
-    alejandra.enable = true; # nix
+    nixpkgs-fmt.enable = true; # nix
     statix.enable = true; # nix static analysis
     deadnix.enable = true; # find dead nix code
     rustfmt.enable = true; # rust
@@ -15,7 +15,7 @@
   };
   settings = {
     formatter = {
-      shellcheck.excludes = [".envrc"];
+      shellcheck.excludes = [ ".envrc" ];
     };
   };
 }

--- a/treefmt.nix
+++ b/treefmt.nix
@@ -13,4 +13,9 @@
     taplo.enable = true; # toml
     yamlfmt.enable = true; # yaml
   };
+  settings = {
+    formatter = {
+      shellcheck.excludes = [".envrc"];
+    };
+  };
 }


### PR DESCRIPTION
Cargo deny released 0.16.0 with breaking changes. These have already hit CI
(will hit nixpkgs ~next week).

This PR makes some changes to accommodate and fix breakage from the update.

Fix: #53 