### PR TITLE
fix: redundant match error

### DIFF
--- a/src/data/config.rs
+++ b/src/data/config.rs
@@ -66,10 +66,7 @@ impl Config {
     #[inline]
     pub fn load(path: &str) -> Self {
         trace!("path: {path:#?}");
-        match Self::new(path) {
-            Ok(config) => config,
-            Err(_) => Config::default(),
-        }
+        Self::new(path).unwrap_or_default()
     }
 
     pub fn bind_addr(&self) -> std::net::SocketAddr {


### PR DESCRIPTION
this breaks CI since a clippy lint dies on it, likely introduced through invisible 1.81 bump from github action lints using latest stable without being pinned